### PR TITLE
fix scrollbar display bug on windows

### DIFF
--- a/vue3/src/pages/Calculator.vue
+++ b/vue3/src/pages/Calculator.vue
@@ -6,7 +6,7 @@
         <small>You can fully use keyboard to calculate</small>
       </div>
       <p
-        class="text-3xl text-right border mt-10 w-56 h-10 overflow-x-scroll"
+        class="text-3xl text-right border mt-10 w-56 h-12 overflow-x-scroll overflow-y-hidden"
         style="direction:rtl"
       >
         {{ currentNum }}
@@ -174,4 +174,20 @@ export default {
 };
 </script>
 
-<style></style>
+<style>
+  ::-webkit-scrollbar {
+    height: 3px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: #f1f1f1;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: #888;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    background: #555;
+  }
+</style>


### PR DESCRIPTION
## before on chrome89 in Win10
![image](https://user-images.githubusercontent.com/44530292/114983938-c7090300-9ec3-11eb-9ab5-6368756a2de0.png)
## after on chrome89 in Win10
![image](https://user-images.githubusercontent.com/44530292/114984017-dbe59680-9ec3-11eb-955b-5c6d15e197b9.png)
 